### PR TITLE
Fix UI issue with navigation and status bars not extending edge-to-edge

### DIFF
--- a/PrintMeMobileApp/app/src/main/java/com/efi/PrintMeGoogle/activities/BarcodeActivity.java
+++ b/PrintMeMobileApp/app/src/main/java/com/efi/PrintMeGoogle/activities/BarcodeActivity.java
@@ -54,10 +54,19 @@ public class BarcodeActivity extends AppCompatActivity {
 
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        
+        // Enable edge-to-edge display
+        WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
+        getWindow().setStatusBarColor(android.graphics.Color.TRANSPARENT);
+        getWindow().setNavigationBarColor(android.graphics.Color.TRANSPARENT);
+        
         WindowInsetsControllerCompat windowInsetsController = WindowCompat.getInsetsController(getWindow(), getWindow().getDecorView());
         if (windowInsetsController != null) {
             windowInsetsController.setAppearanceLightStatusBars(true); // True for dark icons (light background), false for light icons (dark background)
             windowInsetsController.setAppearanceLightNavigationBars(true); // Also set navigation bar icons if needed
+            windowInsetsController.setSystemBarsBehavior(
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+            );
         }
         setContentView(R.layout.fragment_barcode);
         progress=findViewById(R.id.progress);

--- a/PrintMeMobileApp/app/src/main/java/com/efi/PrintMeGoogle/activities/MainActivity.java
+++ b/PrintMeMobileApp/app/src/main/java/com/efi/PrintMeGoogle/activities/MainActivity.java
@@ -48,8 +48,8 @@ public class MainActivity extends AppCompatActivity {
     private String TAG = "MainActivity";
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        // Set to true to tell the system that your layout handles insets.
-        WindowCompat.setDecorFitsSystemWindows(getWindow(), true);
+        // Set to false to tell the system that your layout handles insets.
+        WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
@@ -58,7 +58,18 @@ public class MainActivity extends AppCompatActivity {
         Window window = getWindow();
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
-            window.setStatusBarColor(ContextCompat.getColor(this, R.color.colorPrimaryDark));
+            window.setStatusBarColor(ContextCompat.getColor(this, android.R.color.transparent));
+            window.setNavigationBarColor(ContextCompat.getColor(this, android.R.color.transparent));
+        }
+        
+        // Make the system bars appear on top of the content
+        WindowInsetsControllerCompat windowInsetsController = 
+            ViewCompat.getWindowInsetsController(getWindow().getDecorView());
+        if (windowInsetsController != null) {
+            // Configure the behavior of the hidden system bars
+            windowInsetsController.setSystemBarsBehavior(
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+            );
         }
         Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);

--- a/PrintMeMobileApp/app/src/main/java/com/efi/PrintMeGoogle/activities/RegistrationActivity.java
+++ b/PrintMeMobileApp/app/src/main/java/com/efi/PrintMeGoogle/activities/RegistrationActivity.java
@@ -56,10 +56,19 @@ public class RegistrationActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        
+        // Enable edge-to-edge display
+        WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
+        getWindow().setStatusBarColor(Color.TRANSPARENT);
+        getWindow().setNavigationBarColor(Color.TRANSPARENT);
+        
         WindowInsetsControllerCompat windowInsetsController = WindowCompat.getInsetsController(getWindow(), getWindow().getDecorView());
         if (windowInsetsController != null) {
             windowInsetsController.setAppearanceLightStatusBars(true); // True for dark icons (light background), false for light icons (dark background)
             windowInsetsController.setAppearanceLightNavigationBars(true); // Also set navigation bar icons if needed
+            windowInsetsController.setSystemBarsBehavior(
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+            );
         }
         setContentView(R.layout.activity_registration);
         context = this;

--- a/PrintMeMobileApp/app/src/main/java/com/efi/PrintMeGoogle/activities/ShareActivity.java
+++ b/PrintMeMobileApp/app/src/main/java/com/efi/PrintMeGoogle/activities/ShareActivity.java
@@ -52,6 +52,22 @@ public class ShareActivity extends AppCompatActivity {
 
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        
+        // Enable edge-to-edge display
+        androidx.core.view.WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
+        getWindow().setStatusBarColor(android.graphics.Color.TRANSPARENT);
+        getWindow().setNavigationBarColor(android.graphics.Color.TRANSPARENT);
+        
+        androidx.core.view.WindowInsetsControllerCompat windowInsetsController = 
+            androidx.core.view.WindowCompat.getInsetsController(getWindow(), getWindow().getDecorView());
+        if (windowInsetsController != null) {
+            windowInsetsController.setAppearanceLightStatusBars(true);
+            windowInsetsController.setAppearanceLightNavigationBars(true);
+            windowInsetsController.setSystemBarsBehavior(
+                androidx.core.view.WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+            );
+        }
+        
         setContentView(R.layout.uploadprogressdailog);
         try {
             Intent intent = getIntent();

--- a/PrintMeMobileApp/app/src/main/java/com/efi/PrintMeGoogle/activities/SplashScreenActivity.java
+++ b/PrintMeMobileApp/app/src/main/java/com/efi/PrintMeGoogle/activities/SplashScreenActivity.java
@@ -28,6 +28,11 @@ public class SplashScreenActivity extends AppCompatActivity {
         if (actionBar != null) {
             actionBar.hide();
         }
+        
+        // Enable edge-to-edge display
+        androidx.core.view.WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
+        getWindow().setStatusBarColor(android.graphics.Color.TRANSPARENT);
+        getWindow().setNavigationBarColor(android.graphics.Color.TRANSPARENT);
         boolean isUploading = getUploading();
         if (isUploading == false) {
             File dir = new File(getExternalCacheDir(), "PrintMeTemp");

--- a/PrintMeMobileApp/app/src/main/java/com/efi/PrintMeGoogle/activities/VerificationActivity.java
+++ b/PrintMeMobileApp/app/src/main/java/com/efi/PrintMeGoogle/activities/VerificationActivity.java
@@ -61,10 +61,19 @@ public class VerificationActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        
+        // Enable edge-to-edge display
+        WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
+        getWindow().setStatusBarColor(Color.TRANSPARENT);
+        getWindow().setNavigationBarColor(Color.TRANSPARENT);
+        
         WindowInsetsControllerCompat windowInsetsController = WindowCompat.getInsetsController(getWindow(), getWindow().getDecorView());
         if (windowInsetsController != null) {
             windowInsetsController.setAppearanceLightStatusBars(true); // True for dark icons (light background), false for light icons (dark background)
             windowInsetsController.setAppearanceLightNavigationBars(true); // Also set navigation bar icons if needed
+            windowInsetsController.setSystemBarsBehavior(
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+            );
         }
         setContentView(R.layout.activity_verification);
         //Log.d(TAG," started");

--- a/PrintMeMobileApp/app/src/main/res/layout/activity_main.xml
+++ b/PrintMeMobileApp/app/src/main/res/layout/activity_main.xml
@@ -5,7 +5,7 @@ xmlns:tools="http://schemas.android.com/tools"
 android:id="@+id/container"
 android:layout_width="match_parent"
 android:layout_height="match_parent"
-android:fitsSystemWindows="true"
+android:fitsSystemWindows="false"
 tools:context="com.efi.PrintMeGoogle.activities.MainActivity">
     <include
         layout="@layout/toolbar_layout" />
@@ -13,7 +13,7 @@ tools:context="com.efi.PrintMeGoogle.activities.MainActivity">
     android:id="@+id/frame_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_marginTop="?attr/actionBarSize"
+    android:layout_marginTop="80dp"
     app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
 <com.google.android.material.bottomnavigation.BottomNavigationView
@@ -22,6 +22,9 @@ tools:context="com.efi.PrintMeGoogle.activities.MainActivity">
     android:layout_height="wrap_content"
     app:menu="@menu/bottom_navigation_menu"
     android:layout_gravity="bottom"
+    android:layout_marginStart="0dp"
+    android:layout_marginEnd="0dp"
+    app:layout_insetEdge="bottom"
     style="@style/Widget.MaterialComponents.BottomNavigationView.Colored" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/PrintMeMobileApp/app/src/main/res/layout/toolbar_layout.xml
+++ b/PrintMeMobileApp/app/src/main/res/layout/toolbar_layout.xml
@@ -4,7 +4,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/toolbar"
     android:layout_width="match_parent"
-    android:layout_height="?attr/actionBarSize"
+    android:layout_height="wrap_content"
     android:background="?attr/colorPrimary"
+    android:paddingTop="24dp"
     app:titleTextColor="@android:color/white"
     app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />

--- a/PrintMeMobileApp/app/src/main/res/values/styles.xml
+++ b/PrintMeMobileApp/app/src/main/res/values/styles.xml
@@ -6,9 +6,12 @@
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
-        <item name="android:statusBarColor">@color/colorPrimaryDark</item>
-        <item name="android:navigationBarColor">@color/colorPrimary</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:windowLightStatusBar">true</item>
+        <item name="android:windowTranslucentStatus">false</item>
+        <item name="android:windowTranslucentNavigation">false</item>
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
     </style>
 
     <style name="CustomProgressBar" parent="android:Widget.ProgressBar.Horizontal">


### PR DESCRIPTION
## Description
This PR fixes the UI issue where the navigation bar at the bottom and status bar at the top don't fully merge with the screen edges, leaving small white gaps.

## Changes Made
1. Updated the styles.xml file:
   - Changed status bar and navigation bar colors to transparent
   - Added window properties to enable edge-to-edge display:
     - `android:windowTranslucentStatus="false"`
     - `android:windowTranslucentNavigation="false"`
     - `android:windowDrawsSystemBarBackgrounds="true"`

2. Updated the toolbar_layout.xml:
   - Changed height from fixed size to `wrap_content`
   - Added top padding to account for the status bar

3. Updated all activity Java files to implement edge-to-edge display:
   - MainActivity.java
   - SplashScreenActivity.java
   - RegistrationActivity.java
   - VerificationActivity.java
   - BarcodeActivity.java
   - ShareActivity.java

In each activity, we:
   - Set `WindowCompat.setDecorFitsSystemWindows(getWindow(), false)`
   - Set transparent colors for status and navigation bars
   - Configured the WindowInsetsController to handle system bars behavior

## Testing
These changes should be tested on different Android devices to ensure the UI properly extends edge-to-edge, with the navigation bar at the bottom and status bar at the top properly merging with the screen edges, eliminating the white gaps that were previously visible.

## Screenshots
N/A (Screenshots would be helpful to show the before/after comparison)