### PR TITLE
Fix UI issue with navigation and status bars not extending edge-to-edge

### DIFF
--- a/PrintMeMobileApp/app/src/main/java/com/efi/PrintMeGoogle/activities/BarcodeActivity.java
+++ b/PrintMeMobileApp/app/src/main/java/com/efi/PrintMeGoogle/activities/BarcodeActivity.java
@@ -54,11 +54,26 @@ public class BarcodeActivity extends AppCompatActivity {
 
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        WindowInsetsControllerCompat windowInsetsController = WindowCompat.getInsetsController(getWindow(), getWindow().getDecorView());
+        
+        // Enable edge-to-edge display
+        WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
+        
+        // Set transparent status and navigation bars
+        Window window = getWindow();
+        window.setStatusBarColor(android.graphics.Color.TRANSPARENT);
+        window.setNavigationBarColor(android.graphics.Color.TRANSPARENT);
+        
+        // Configure system bars behavior
+        WindowInsetsControllerCompat windowInsetsController = 
+            WindowCompat.getInsetsController(getWindow(), getWindow().getDecorView());
         if (windowInsetsController != null) {
-            windowInsetsController.setAppearanceLightStatusBars(true); // True for dark icons (light background), false for light icons (dark background)
-            windowInsetsController.setAppearanceLightNavigationBars(true); // Also set navigation bar icons if needed
+            windowInsetsController.setAppearanceLightStatusBars(true); // True for dark icons (light background)
+            windowInsetsController.setAppearanceLightNavigationBars(true); // Also set navigation bar icons
+            windowInsetsController.setSystemBarsBehavior(
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+            );
         }
+        
         setContentView(R.layout.fragment_barcode);
         progress=findViewById(R.id.progress);
         barcode_layout=findViewById(R.id.barcode_layout);

--- a/PrintMeMobileApp/app/src/main/java/com/efi/PrintMeGoogle/activities/MainActivity.java
+++ b/PrintMeMobileApp/app/src/main/java/com/efi/PrintMeGoogle/activities/MainActivity.java
@@ -48,18 +48,28 @@ public class MainActivity extends AppCompatActivity {
     private String TAG = "MainActivity";
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        // Set to true to tell the system that your layout handles insets.
-        WindowCompat.setDecorFitsSystemWindows(getWindow(), true);
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
-
-        // Set the custom status bar color. This is independent of the layout
-        // and sets the background color of the status bar itself.
+        
+        // Enable edge-to-edge display
+        WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
+        
+        // Set transparent status and navigation bars
         Window window = getWindow();
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
-            window.setStatusBarColor(ContextCompat.getColor(this, R.color.colorPrimaryDark));
+        window.setStatusBarColor(android.graphics.Color.TRANSPARENT);
+        window.setNavigationBarColor(android.graphics.Color.TRANSPARENT);
+        
+        // Configure system bars behavior
+        WindowInsetsControllerCompat windowInsetsController = 
+            WindowCompat.getInsetsController(getWindow(), getWindow().getDecorView());
+        if (windowInsetsController != null) {
+            windowInsetsController.setAppearanceLightStatusBars(true);
+            windowInsetsController.setAppearanceLightNavigationBars(true);
+            windowInsetsController.setSystemBarsBehavior(
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+            );
         }
+        
+        setContentView(R.layout.activity_main);
         Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
         actionbar = getSupportActionBar();

--- a/PrintMeMobileApp/app/src/main/java/com/efi/PrintMeGoogle/activities/RegistrationActivity.java
+++ b/PrintMeMobileApp/app/src/main/java/com/efi/PrintMeGoogle/activities/RegistrationActivity.java
@@ -56,11 +56,26 @@ public class RegistrationActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        WindowInsetsControllerCompat windowInsetsController = WindowCompat.getInsetsController(getWindow(), getWindow().getDecorView());
+        
+        // Enable edge-to-edge display
+        WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
+        
+        // Set transparent status and navigation bars
+        Window window = getWindow();
+        window.setStatusBarColor(android.graphics.Color.TRANSPARENT);
+        window.setNavigationBarColor(android.graphics.Color.TRANSPARENT);
+        
+        // Configure system bars behavior
+        WindowInsetsControllerCompat windowInsetsController = 
+            WindowCompat.getInsetsController(getWindow(), getWindow().getDecorView());
         if (windowInsetsController != null) {
-            windowInsetsController.setAppearanceLightStatusBars(true); // True for dark icons (light background), false for light icons (dark background)
-            windowInsetsController.setAppearanceLightNavigationBars(true); // Also set navigation bar icons if needed
+            windowInsetsController.setAppearanceLightStatusBars(true); // True for dark icons (light background)
+            windowInsetsController.setAppearanceLightNavigationBars(true); // Also set navigation bar icons
+            windowInsetsController.setSystemBarsBehavior(
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+            );
         }
+        
         setContentView(R.layout.activity_registration);
         context = this;
         //////Log.d(TAG, "started");

--- a/PrintMeMobileApp/app/src/main/java/com/efi/PrintMeGoogle/activities/ShareActivity.java
+++ b/PrintMeMobileApp/app/src/main/java/com/efi/PrintMeGoogle/activities/ShareActivity.java
@@ -12,11 +12,14 @@ import android.provider.MediaStore;
 import android.provider.OpenableColumns;
 import android.util.Log;
 import android.view.View;
+import android.view.Window;
 import android.webkit.MimeTypeMap;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsControllerCompat;
 
 import com.efi.PrintMeGoogle.R;
 import com.efi.PrintMeGoogle.constants.GeneralConstants;
@@ -52,6 +55,24 @@ public class ShareActivity extends AppCompatActivity {
 
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        
+        // Enable edge-to-edge display
+        WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
+        
+        // Set transparent status and navigation bars
+        Window window = getWindow();
+        window.setStatusBarColor(android.graphics.Color.TRANSPARENT);
+        window.setNavigationBarColor(android.graphics.Color.TRANSPARENT);
+        
+        // Configure system bars behavior
+        WindowInsetsControllerCompat windowInsetsController = 
+            WindowCompat.getInsetsController(getWindow(), getWindow().getDecorView());
+        if (windowInsetsController != null) {
+            windowInsetsController.setSystemBarsBehavior(
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+            );
+        }
+        
         setContentView(R.layout.uploadprogressdailog);
         try {
             Intent intent = getIntent();

--- a/PrintMeMobileApp/app/src/main/java/com/efi/PrintMeGoogle/activities/SplashScreenActivity.java
+++ b/PrintMeMobileApp/app/src/main/java/com/efi/PrintMeGoogle/activities/SplashScreenActivity.java
@@ -5,9 +5,12 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
 import android.util.Log;
+import android.view.Window;
 
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsControllerCompat;
 
 import com.efi.PrintMeGoogle.R;
 import com.efi.PrintMeGoogle.utils.CommonUtils;
@@ -22,6 +25,24 @@ public class SplashScreenActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        
+        // Enable edge-to-edge display
+        WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
+        
+        // Set transparent status and navigation bars
+        Window window = getWindow();
+        window.setStatusBarColor(android.graphics.Color.TRANSPARENT);
+        window.setNavigationBarColor(android.graphics.Color.TRANSPARENT);
+        
+        // Configure system bars behavior
+        WindowInsetsControllerCompat windowInsetsController = 
+            WindowCompat.getInsetsController(getWindow(), getWindow().getDecorView());
+        if (windowInsetsController != null) {
+            windowInsetsController.setSystemBarsBehavior(
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+            );
+        }
+        
         setContentView(R.layout.activity_splash_screen);
         context = this;
         ActionBar actionBar = getSupportActionBar();

--- a/PrintMeMobileApp/app/src/main/java/com/efi/PrintMeGoogle/activities/VerificationActivity.java
+++ b/PrintMeMobileApp/app/src/main/java/com/efi/PrintMeGoogle/activities/VerificationActivity.java
@@ -61,11 +61,26 @@ public class VerificationActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        WindowInsetsControllerCompat windowInsetsController = WindowCompat.getInsetsController(getWindow(), getWindow().getDecorView());
+        
+        // Enable edge-to-edge display
+        WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
+        
+        // Set transparent status and navigation bars
+        Window window = getWindow();
+        window.setStatusBarColor(android.graphics.Color.TRANSPARENT);
+        window.setNavigationBarColor(android.graphics.Color.TRANSPARENT);
+        
+        // Configure system bars behavior
+        WindowInsetsControllerCompat windowInsetsController = 
+            WindowCompat.getInsetsController(getWindow(), getWindow().getDecorView());
         if (windowInsetsController != null) {
-            windowInsetsController.setAppearanceLightStatusBars(true); // True for dark icons (light background), false for light icons (dark background)
-            windowInsetsController.setAppearanceLightNavigationBars(true); // Also set navigation bar icons if needed
+            windowInsetsController.setAppearanceLightStatusBars(true); // True for dark icons (light background)
+            windowInsetsController.setAppearanceLightNavigationBars(true); // Also set navigation bar icons
+            windowInsetsController.setSystemBarsBehavior(
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+            );
         }
+        
         setContentView(R.layout.activity_verification);
         //Log.d(TAG," started");
         context=this;

--- a/PrintMeMobileApp/app/src/main/res/layout/toolbar_layout.xml
+++ b/PrintMeMobileApp/app/src/main/res/layout/toolbar_layout.xml
@@ -4,7 +4,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/toolbar"
     android:layout_width="match_parent"
-    android:layout_height="?attr/actionBarSize"
+    android:layout_height="wrap_content"
+    android:paddingTop="24dp"
     android:background="?attr/colorPrimary"
     app:titleTextColor="@android:color/white"
     app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />

--- a/PrintMeMobileApp/app/src/main/res/values/styles.xml
+++ b/PrintMeMobileApp/app/src/main/res/values/styles.xml
@@ -6,9 +6,12 @@
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
-        <item name="android:statusBarColor">@color/colorPrimaryDark</item>
-        <item name="android:navigationBarColor">@color/colorPrimary</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:windowLightStatusBar">true</item>
+        <item name="android:windowTranslucentStatus">false</item>
+        <item name="android:windowTranslucentNavigation">false</item>
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
     </style>
 
     <style name="CustomProgressBar" parent="android:Widget.ProgressBar.Horizontal">


### PR DESCRIPTION
## Description
This PR fixes the UI issue where the navigation bar at the bottom and status bar at the top don't fully merge with the screen edges, leaving small white gaps.

## Changes Made
1. Updated the styles.xml file:
   - Changed status bar and navigation bar colors to transparent
   - Added window properties to enable edge-to-edge display:
     - `android:windowTranslucentStatus="false"`
     - `android:windowTranslucentNavigation="false"`
     - `android:windowDrawsSystemBarBackgrounds="true"`

2. Updated the toolbar_layout.xml:
   - Changed height from fixed size to `wrap_content`
   - Added top padding to account for the status bar

3. Updated all activity Java files to implement edge-to-edge display:
   - MainActivity.java
   - SplashScreenActivity.java
   - RegistrationActivity.java
   - VerificationActivity.java
   - BarcodeActivity.java
   - ShareActivity.java

In each activity, we:
   - Set `WindowCompat.setDecorFitsSystemWindows(getWindow(), false)`
   - Set transparent colors for status and navigation bars
   - Configured the WindowInsetsController to handle system bars behavior

## Testing
These changes should be tested on different Android devices to ensure the UI properly extends edge-to-edge, with the navigation bar at the bottom and status bar at the top properly merging with the screen edges, eliminating the white gaps that were previously visible.

## Screenshots
N/A (Screenshots would be helpful to show the before/after comparison)